### PR TITLE
feat: add --version/-V support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,9 @@ categories.workspace = true
 keywords.workspace = true
 
 [features]
-default = ["help"]
+default = ["help", "version"]
 help = []
+version = []
 
 [dependencies]
 os_str_bytes = { version = "7.1.0", default-features = false, features = ["raw_os_str"] }

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Writing your CLI structs first before deciding which crate to use.
 ## Similar: Full-featured, out of the box
 
 palc also aim to provide a decent CLI experience under default features:
-help generations, non-UTF-8 support, argument constraints, `Args` composition,
+help generations, version output, non-UTF-8 support, argument constraints, `Args` composition,
 subcommands, you name it.
 
 Though some of clap features are not-yet-implemented.
@@ -118,7 +118,7 @@ Though some of clap features are not-yet-implemented.
 
   - [x] Long help `--help`.
   - [ ] Short help `-h`.
-  - [ ] Version `--version`.
+  - [x] Version `--version` and `-V`.
   - [x] Custom header and footer.
   - [ ] Hiding.
   - [ ] Possible values of enums.

--- a/derive/src/derive_args.rs
+++ b/derive/src/derive_args.rs
@@ -891,6 +891,12 @@ impl ToTokens for RawArgsInfo<'_> {
 
         let has_optional_named = named_fields.iter().any(|f| !f.required && !f.hide);
 
+        let version = match self.0.cmd_meta.and_then(|m| m.version.as_ref()) {
+            Some(Override::Explicit(expr)) => quote! { __rt::Some(#expr) },
+            Some(Override::Inherit) => quote! { __rt::Some(env!("CARGO_PKG_VERSION")) },
+            None => quote! { __rt::None },
+        };
+
         let flatten_tys = self.0.flatten_tys();
 
         tokens.extend(quote! {
@@ -903,6 +909,7 @@ impl ToTokens for RawArgsInfo<'_> {
                 #subcmd_opt,
                 #has_optional_named,
                 #help_display,
+                __rt::__gate_version!(__rt::None, #version),
                 &[#(<#flatten_tys as __rt::Args>::__INFO),*],
             )
         });

--- a/derive/src/derive_subcommand.rs
+++ b/derive/src/derive_subcommand.rs
@@ -81,7 +81,11 @@ fn expand_for_enum<'a>(def: &'a DeriveInput, data: &'a DataEnum) -> SubcommandIm
                     let help = HelpDisplay { parse: None, cmd_meta: cmd_meta.as_deref() }
                         .to_token_stream();
                     let info = quote! {
-                        &__rt::RawArgsInfo::new("", &[], &[], __rt::None, false, false, #help, &[])
+                        &__rt::RawArgsInfo::new(
+                            "", &[], &[], __rt::None, false, false, #help,
+                            __rt::__gate_version!(__rt::None, __rt::None),
+                            &[],
+                        )
                     };
                     (info, VariantKind::Unit)
                 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -41,6 +41,9 @@ struct Inner {
 
     /// Rendered help message.
     help: Option<String>,
+
+    /// Rendered version message.
+    version: Option<String>,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -65,6 +68,7 @@ pub(crate) enum ErrorKind {
 
     // Not really an error, but for bubbling out.
     Help,
+    Version,
 
     // User errors.
     Custom,
@@ -137,6 +141,7 @@ impl fmt::Display for Error {
 
             // Will be rendered at the end.
             ErrorKind::Help => format_args!(""),
+            ErrorKind::Version => format_args!(""),
 
             ErrorKind::Custom => return fmt::Display::fmt(e.source.as_deref().unwrap(), f),
         };
@@ -153,6 +158,9 @@ impl fmt::Display for Error {
         if e.kind == ErrorKind::Help {
             f.write_str(e.help.as_deref().unwrap_or("help is not available"))?;
         }
+        if e.kind == ErrorKind::Version {
+            f.write_str(e.version.as_deref().unwrap_or("version is not available"))?;
+        }
 
         Ok(())
     }
@@ -167,6 +175,7 @@ impl Error {
             source: None,
             contextual_help: String::new(),
             help: None,
+            version: None,
         }))
     }
 
@@ -185,6 +194,19 @@ impl Error {
     /// If this error is not about help or feature "help" is disabled, `Err(self)` is returned.
     pub fn try_into_help(mut self) -> Result<String, Self> {
         if let Some(help) = self.0.help.take() { Ok(help) } else { Err(self) }
+    }
+
+    /// Render the version string if this error indicates a `--version` is encountered.
+    ///
+    /// # Errors
+    ///
+    /// If this error is not about version or feature "version" is disabled, `Err(self)` is returned.
+    pub fn try_into_version(mut self) -> Result<String, Self> {
+        if let Some(version) = self.0.version.take() { Ok(version) } else { Err(self) }
+    }
+
+    pub(crate) fn kind(&self) -> ErrorKind {
+        self.0.kind
     }
 
     pub(crate) fn with_source(mut self, source: DynStdError) -> Self {
@@ -213,6 +235,20 @@ impl Error {
         if self.0.kind == ErrorKind::Help {
             let out = self.0.help.insert(String::new());
             crate::help::render_help_into(out, frame);
+        }
+        self
+    }
+
+    #[cfg(not(feature = "version"))]
+    pub(crate) fn maybe_render_version(self, _: &ArgsFrame) -> Self {
+        self
+    }
+
+    #[cfg(feature = "version")]
+    pub(crate) fn maybe_render_version(mut self, frame: &ArgsFrame) -> Self {
+        if self.0.kind == ErrorKind::Version {
+            let out = self.0.version.insert(String::new());
+            crate::version::render_version_into(out, frame);
         }
         self
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,9 @@ mod values;
 #[cfg(feature = "help")]
 mod help;
 
+#[cfg(feature = "version")]
+mod version;
+
 pub use crate::error::Error;
 use crate::runtime::ParserFlavor;
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -48,7 +51,7 @@ pub mod __private {
 
     // Macros.
     pub use crate::util::{const_concat_impl, const_concat_len};
-    pub use crate::{__const_concat, __gate_help};
+    pub use crate::{__const_concat, __gate_help, __gate_version};
     pub use std::{assert, concat, env, format_args, unimplemented, unreachable};
 
     pub use crate::values::{
@@ -70,6 +73,10 @@ pub trait Parser: ParserInternal + Sized + 'static {
         match Self::try_parse_from(std::env::args_os()) {
             Ok(v) => v,
             Err(err) => {
+                if err.kind() == ErrorKind::Version {
+                    println!("{err}");
+                    std::process::exit(0);
+                }
                 eprintln!("{err}");
                 std::process::exit(1);
             }

--- a/src/refl.rs
+++ b/src/refl.rs
@@ -98,11 +98,15 @@ pub struct RawArgsInfo {
     /// - `{:.5}`: `after_long_help`
     #[cfg(feature = "help")]
     pub(crate) help: &'static dyn fmt::Display,
+
+    /// Version string from `#[command(version = "...")]`.
+    #[cfg(feature = "version")]
+    pub(crate) version: Option<&'static str>,
 }
 
 impl RawArgsInfo {
     // Used by proc-macro.
-    pub const EMPTY_REF: &'static Self = &Self::new("", &[], &[], None, false, false, &"", &[]);
+    pub const EMPTY_REF: &'static Self = &Self::new("", &[], &[], None, false, false, &"", None, &[]);
 
     // Used by proc-macro.
     #[expect(clippy::too_many_arguments, reason = "proc-macro needs to pass this many information")]
@@ -115,6 +119,7 @@ impl RawArgsInfo {
         is_subcmd_optional: bool,
         mut has_optional_named: bool,
         help: &'static dyn fmt::Display,
+        version: Option<&'static str>,
         flattened: &[&RawArgsInfo],
     ) -> RawArgsInfo {
         #[cfg(feature = "help")]
@@ -139,6 +144,8 @@ impl RawArgsInfo {
             has_optional_named,
             #[cfg(feature = "help")]
             help,
+            #[cfg(feature = "version")]
+            version,
         }
     }
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -83,11 +83,11 @@ impl<A: Args> ParserFlavor<A> for StructParserFlavor<A> {
     fn run_parser(p: &mut RawParser, program_name: &OsStr) -> Result<A> {
         let mut out = None;
         let mut frame = CommandFrame {
-            #[cfg(feature = "help")]
+            #[cfg(any(feature = "help", feature = "version"))]
             name: &program_name.to_string_lossy(),
             parent: &mut (),
         };
-        #[cfg(not(feature = "help"))]
+        #[cfg(not(any(feature = "help", feature = "version")))]
         {
             let _ = program_name;
         }
@@ -218,6 +218,16 @@ pub trait Frame {
 
     #[cfg(feature = "help")]
     fn collect_command_prefix(&self, out: &mut String);
+
+    #[cfg(feature = "version")]
+    fn program_name(&self) -> Option<&str> {
+        None
+    }
+
+    #[cfg(feature = "version")]
+    fn version(&self) -> Option<&'static str> {
+        None
+    }
 }
 
 // NB: proc-macro constructs this.
@@ -252,6 +262,16 @@ impl Frame for ArgsFrame<'_, '_> {
     fn collect_command_prefix(&self, out: &mut String) {
         self.parent.collect_command_prefix(out);
     }
+
+    #[cfg(feature = "version")]
+    fn program_name(&self) -> Option<&str> {
+        self.parent.program_name()
+    }
+
+    #[cfg(feature = "version")]
+    fn version(&self) -> Option<&'static str> {
+        self.info.version.or_else(|| self.parent.version())
+    }
 }
 
 /// An auxiliary frame recording encountered (sub)command names for "Usage".
@@ -263,7 +283,7 @@ impl Frame for ArgsFrame<'_, '_> {
 // TODO: Can we elide this frame if help is disabled? Currently this also serves
 // as a global argument boundary.
 struct CommandFrame<'a> {
-    #[cfg(feature = "help")]
+    #[cfg(any(feature = "help", feature = "version"))]
     name: &'a str,
     parent: &'a mut dyn Frame,
 }
@@ -281,6 +301,19 @@ impl Frame for CommandFrame<'_> {
         self.parent.collect_command_prefix(out);
         out.push(' ');
         out.push_str(self.name);
+    }
+
+    #[cfg(feature = "version")]
+    fn program_name(&self) -> Option<&str> {
+        match self.parent.program_name() {
+            Some(name) => Some(name),
+            None => Some(self.name),
+        }
+    }
+
+    #[cfg(feature = "version")]
+    fn version(&self) -> Option<&'static str> {
+        self.parent.version()
     }
 }
 
@@ -548,11 +581,11 @@ fn run_parser(p: &mut RawParser, frame: &mut ArgsFrame) -> Result<()> {
                 && let Some((name, idx)) = subcmd_info.search(&arg)
             {
                 let mut frame = CommandFrame {
-                    #[cfg(feature = "help")]
+                    #[cfg(any(feature = "help", feature = "version"))]
                     name,
                     parent: frame,
                 };
-                #[cfg(not(feature = "help"))]
+                #[cfg(not(any(feature = "help", feature = "version")))]
                 {
                     let _ = name;
                 }
@@ -611,6 +644,17 @@ fn visit_named(
         #[cfg(feature = "help")]
         if enc_name == "h" || enc_name == "--help" {
             return Err(crate::Error::from(ErrorKind::Help).maybe_render_help(frame));
+        }
+
+        // TODO: Configurable version?
+        #[cfg(feature = "version")]
+        if enc_name == "V" || enc_name == "--version" {
+            if frame.version().is_some() {
+                return Err(
+                    crate::Error::from(ErrorKind::Version).maybe_render_version(frame)
+                );
+            }
+            // If no version is configured, fall through to unknown argument error.
         }
 
         let mut input_arg = OsString::with_capacity(1 + enc_name.len());

--- a/src/util.rs
+++ b/src/util.rs
@@ -18,6 +18,24 @@ macro_rules! __gate_help {
     };
 }
 
+#[cfg(feature = "version")]
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __gate_version {
+    ($disabled:expr, $($enabled:tt)*) => {
+        $($enabled)*
+    };
+}
+
+#[cfg(not(feature = "version"))]
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __gate_version {
+    ($disabled:expr, $($enabled:tt)*) => {
+        $disabled
+    };
+}
+
 #[macro_export]
 #[doc(hidden)]
 macro_rules! __const_concat {

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,0 +1,14 @@
+use crate::runtime::{ArgsFrame, Frame};
+
+#[cold]
+pub(crate) fn render_version_into(out: &mut String, frame: &ArgsFrame) {
+    if let Some(name) = frame.program_name() {
+        out.push_str(name);
+        out.push(' ');
+    }
+    // `version()` is known to be `Some` since the caller already checked
+    // `frame.version()` before constructing `ErrorKind::Version`.
+    if let Some(version) = frame.version() {
+        out.push_str(version);
+    }
+}

--- a/tests/version.rs
+++ b/tests/version.rs
@@ -1,0 +1,71 @@
+#![cfg(feature = "version")]
+#![expect(dead_code, reason = "only for version generation")]
+use expect_test::{Expect, expect};
+use palc::{Parser, Subcommand};
+
+/// My great app.
+#[derive(Parser)]
+#[command(version = "1.2.3")]
+struct VersionCli {
+    /// Log more details.
+    #[arg(short = 'v')]
+    verbose: bool,
+
+    #[command(subcommand)]
+    command: Option<Commands>,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Run the app.
+    Run,
+}
+
+#[track_caller]
+fn assert_version<P: Parser>(args: &[&str], expect: Expect) {
+    let version = P::try_parse_from(args).err().unwrap().try_into_version().unwrap();
+    expect.assert_eq(&version);
+}
+
+#[test]
+fn version_long() {
+    assert_version::<VersionCli>(
+        &["me", "--version"],
+        expect![["me 1.2.3"]],
+    );
+}
+
+#[test]
+fn version_short() {
+    assert_version::<VersionCli>(
+        &["me", "-V"],
+        expect![["me 1.2.3"]],
+    );
+}
+
+#[test]
+fn version_with_subcommand() {
+    // --version should work even after a subcommand name.
+    assert_version::<VersionCli>(
+        &["me", "run", "--version"],
+        expect![["me 1.2.3"]],
+    );
+}
+
+#[test]
+fn version_inherit() {
+    /// Test app.
+    #[derive(Parser)]
+    #[command(version)]
+    struct InheritVersionCli {}
+
+    let version = InheritVersionCli::try_parse_from(["me", "--version"])
+        .err()
+        .unwrap()
+        .try_into_version()
+        .unwrap();
+    // The inherited version is env!("CARGO_PKG_VERSION") from the test crate's
+    // Cargo.toml, which resolves to palc's version "0.0.2".
+    let expected = format!("me {}", env!("CARGO_PKG_VERSION"));
+    assert_eq!(version, expected);
+}


### PR DESCRIPTION
Gated behind new `version` feature (in default features, like `help`). Follows the same pattern as --help/-h: detected as a fallback in visit_named(), walks the frame chain to find the top-level version string, and exits with code 0 to stdout.

- command(version) inherits from env!("CARGO_PKG_VERSION")
- command(version = EXPR) uses the literal expression
- -V and --version both supported
- Works at any subcommand depth

Generated by deepseek-v4